### PR TITLE
Allow batching of NER API predictions

### DIFF
--- a/daluke/api/__init__.py
+++ b/daluke/api/__init__.py
@@ -1,3 +1,3 @@
-from daluke.api.data import example_from_str, masked_example_from_str, ner_example_from_str
+from daluke.api.data import example_from_str, masked_example_from_str, ner_examples_from_str
 from daluke.api.predict import predict_mlm, predict_ner
 from daluke.api.automodels import AutoRepresentationDaLUKE, AutoMLMDaLUKE, AutoNERDaLUKE

--- a/tests/api/test_data.py
+++ b/tests/api/test_data.py
@@ -1,6 +1,6 @@
 import torch
 from transformers import AutoTokenizer
-from daluke import example_from_str, masked_example_from_str, ner_example_from_str, daBERT
+from daluke import example_from_str, masked_example_from_str, ner_examples_from_str, daBERT
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -48,7 +48,12 @@ def test_masked_example_from_str():
     assert torch.all(res.word_mask == torch.BoolTensor([False, False, True, False]).to(device))
     assert torch.all(res.entities.ids == torch.IntTensor([4, 2]).to(device))
 
-def test_ner_example_from_str():
-    res = ner_example_from_str("Hej med dig", DummyDaLUKE())
+def test_ner_examples_from_str():
+    res = ner_examples_from_str(["Hej med dig"], DummyDaLUKE())[0]
     assert res.entities.fullword_spans == [[(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]]
     assert torch.all(res.entities.ids == torch.IntTensor([1,1,1,1,1,1]).to(device))
+
+def test_multiple_ner_examples_from_str():
+    res = ner_examples_from_str(["Hej med dig", "Hej med dig også"], DummyDaLUKE())[0]
+    assert res.entities.fullword_spans[0] == [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+    assert res.entities.fullword_spans[1] == [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]


### PR DESCRIPTION
JOHAN SEBASTIAN BACH'ED API

Se commit-besked for kontekst

Dette testes f.eks. ved at køre
```py
from daluke import predict_ner, AutoNERDaLUKE
d = AutoNERDALUKE()
predict_ner("Hej med dig", d)
predict_ner(["Hej med dig", "hej med mig"], d)
```

